### PR TITLE
LUT-29761: Ensure that the resubmitted answers go through the validation control process

### DIFF
--- a/src/java/fr/paris/lutece/plugins/workflow/modules/forms/service/AbstractFormResponseService.java
+++ b/src/java/fr/paris/lutece/plugins/workflow/modules/forms/service/AbstractFormResponseService.java
@@ -137,4 +137,16 @@ public abstract class AbstractFormResponseService
         }
         return bIsValid;
     }
+
+    /**
+     * Check whether the values from the given List of FormQuestionResponse are valid
+     * 
+     * @param listFormQuestionResponse
+     *            the List of FormQuestionResponse to check
+     * @return true if all the Responses have valid values, returns false otherwise
+     */
+    protected boolean areFormResponsesValid( List<FormQuestionResponse> listFormQuestionResponse )
+    {
+        return _formsTaskService.areFormQuestionResponsesValid( listFormQuestionResponse );
+    }
 }

--- a/src/java/fr/paris/lutece/plugins/workflow/modules/forms/service/CompleteFormResponseService.java
+++ b/src/java/fr/paris/lutece/plugins/workflow/modules/forms/service/CompleteFormResponseService.java
@@ -35,6 +35,7 @@ package fr.paris.lutece.plugins.workflow.modules.forms.service;
 
 import java.sql.Date;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.stream.Collectors;
@@ -43,6 +44,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.servlet.http.HttpServletRequest;
 
+import fr.paris.lutece.plugins.forms.business.FormQuestionResponse;
 import fr.paris.lutece.plugins.forms.business.FormResponse;
 import fr.paris.lutece.plugins.forms.business.Question;
 import fr.paris.lutece.plugins.forms.business.QuestionHome;
@@ -91,6 +93,9 @@ public class CompleteFormResponseService extends AbstractFormResponseService imp
 
     @Inject
     private ICompleteFormResponseTaskHistoryService _completeFormResponseTaskHistoryService;
+
+    // List of FormQuestionResponse to store the user's new Responses 
+    private List<FormQuestionResponse> _submittedFormResponses;
 
     @Override
     public List<Question> findListQuestionUsedCorrectForm( FormResponse formResponse )
@@ -226,7 +231,15 @@ public class CompleteFormResponseService extends AbstractFormResponseService imp
             return false;
         }
         List<Question> listQuestions = getListQuestionToEdit( response, completeFormResponse.getListCompleteReponseValues( ) );
-
+        // Get the values of the newly submitted Responses
+        _submittedFormResponses = _formsTaskService.getSubmittedFormQuestionResponses( request, response, listQuestions );
+        // Check if the new Responses are valid
+        if ( !areFormResponsesValid( _submittedFormResponses ) )
+        {
+            return false;
+        }
+        // Reset the content of the List
+        _submittedFormResponses = Collections.emptyList( );
         doEditResponseData( request, response, listQuestions, idTask, idHistory );
         return true;
     }
@@ -261,5 +274,11 @@ public class CompleteFormResponseService extends AbstractFormResponseService imp
         history.setNewValue( _formsTaskService.createPreviousNewValue( editableResponse.getResponseFromForm( ) ) );
 
         _completeFormResponseTaskHistoryService.create( history );
+    }
+
+    @Override
+    public List<FormQuestionResponse> getSubmittedFormResponseList( )
+    {
+        return _submittedFormResponses;
     }
 }

--- a/src/java/fr/paris/lutece/plugins/workflow/modules/forms/service/ICompleteFormResponseService.java
+++ b/src/java/fr/paris/lutece/plugins/workflow/modules/forms/service/ICompleteFormResponseService.java
@@ -38,6 +38,7 @@ import java.util.Locale;
 
 import javax.servlet.http.HttpServletRequest;
 
+import fr.paris.lutece.plugins.forms.business.FormQuestionResponse;
 import fr.paris.lutece.plugins.forms.business.FormResponse;
 import fr.paris.lutece.plugins.forms.business.Question;
 import fr.paris.lutece.plugins.genericattributes.business.Entry;
@@ -162,4 +163,11 @@ public interface ICompleteFormResponseService
      *            the Response
      */
     void doCompleteResponse( CompleteFormResponse completeFormResponse );
+
+    /**
+     * Get the List of FormQuestionResponse containing the new Responses that the user is trying to submit
+     * 
+     * @return A List of FormQuestionResponse
+     */
+    List<FormQuestionResponse> getSubmittedFormResponseList( );
 }

--- a/src/java/fr/paris/lutece/plugins/workflow/modules/forms/service/IResubmitFormResponseService.java
+++ b/src/java/fr/paris/lutece/plugins/workflow/modules/forms/service/IResubmitFormResponseService.java
@@ -38,6 +38,7 @@ import java.util.Locale;
 
 import javax.servlet.http.HttpServletRequest;
 
+import fr.paris.lutece.plugins.forms.business.FormQuestionResponse;
 import fr.paris.lutece.plugins.forms.business.FormResponse;
 import fr.paris.lutece.plugins.forms.business.Question;
 import fr.paris.lutece.plugins.genericattributes.business.Entry;
@@ -176,4 +177,11 @@ public interface IResubmitFormResponseService
      *            the Response
      */
     void doCompleteResponse( ResubmitFormResponse resubmitFormResponse );
+
+    /**
+     * Get the List of FormQuestionResponse containing the new Responses that the user is trying to submit
+     * 
+     * @return A List of FormQuestionResponse
+     */
+    List<FormQuestionResponse> getSubmittedFormResponseList( );
 }

--- a/src/java/fr/paris/lutece/plugins/workflow/modules/forms/service/ResubmitFormResponseService.java
+++ b/src/java/fr/paris/lutece/plugins/workflow/modules/forms/service/ResubmitFormResponseService.java
@@ -35,6 +35,7 @@ package fr.paris.lutece.plugins.workflow.modules.forms.service;
 
 import java.sql.Date;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.stream.Collectors;
@@ -104,6 +105,9 @@ public class ResubmitFormResponseService extends AbstractFormResponseService imp
 
     @Inject
     private IResubmitFormResponseTaskHistoryService _resubmitFormResponseTaskHistoryService;
+
+    // List of FormQuestionResponse to store the user's new Responses 
+    private List<FormQuestionResponse> _submittedFormQuestionResponses;
 
     @Override
     public ResubmitFormResponse find( int nIdHistory, int nIdTask )
@@ -270,7 +274,15 @@ public class ResubmitFormResponseService extends AbstractFormResponseService imp
             return false;
         }
         List<Question> listQuestions = getListQuestionToEdit( response, resubmitFormResponse.getListResubmitReponseValues( ) );
-
+        // Get the values of the newly submitted Responses
+        _submittedFormQuestionResponses = _formsTaskService.getSubmittedFormQuestionResponses( request, response, listQuestions );
+        // Check if the new Responses are valid
+        if ( !areFormResponsesValid( _submittedFormQuestionResponses ) )
+        {
+            return false;
+        }
+        // Reset the content of the List
+        _submittedFormQuestionResponses = Collections.emptyList( );
         doEditResponseData( request, response, listQuestions, idTask, idHistory );
         return true;
     }
@@ -306,5 +318,11 @@ public class ResubmitFormResponseService extends AbstractFormResponseService imp
         resubmitFormResponse.setIsComplete( true );
         resubmitFormResponse.setDateCompleted( new Date( System.currentTimeMillis( ) ) );
         update( resubmitFormResponse );
+    }
+
+    @Override
+    public List<FormQuestionResponse> getSubmittedFormResponseList( )
+    {
+        return _submittedFormQuestionResponses;
     }
 }

--- a/src/java/fr/paris/lutece/plugins/workflow/modules/forms/service/task/IFormsTaskService.java
+++ b/src/java/fr/paris/lutece/plugins/workflow/modules/forms/service/task/IFormsTaskService.java
@@ -33,6 +33,7 @@
  */
 package fr.paris.lutece.plugins.workflow.modules.forms.service.task;
 
+import java.util.Collection;
 import java.util.List;
 
 import javax.servlet.http.HttpServletRequest;
@@ -98,6 +99,26 @@ public interface IFormsTaskService
 
     List<String> buildFormStepDisplayTreeList( HttpServletRequest request, List<Step> listStep, List<Question> listQuestionToDisplay, FormResponse formResponse,
             DisplayType displayType );
+
+    /**
+     * Get a List of Strings containing the models and values displayed to the user, for each existing Step
+     * 
+     * @param request
+     *            the HTTP request
+     * @param listStep
+     *            the List of Steps being processed
+     * @param listQuestionToDisplay
+     *            the List of Question that should be resubmitted by the user
+     * @param listFormQuestionResponse
+     *            the List of new FormQuestionResponse being submitted by the user
+     * @param formResponse
+     *            the FormResponse being processed
+     * @param displayType
+     *            the DisplayType used in the template
+     * @return a List of Strings containing the complete template 
+     */
+    List<String> buildFormStepDisplayTree( HttpServletRequest request, List<Step> listStep, List<Question> listQuestionToDisplay,
+            List<FormQuestionResponse> listFormQuestionResponse, FormResponse formResponse, DisplayType displayType );
 
     /**
      * Finds the responses that have changed
@@ -174,4 +195,26 @@ public interface IFormsTaskService
      * @return a value ready to be inserted in history
      */
     String createPreviousNewValue( FormQuestionResponse responseForm );
+
+    /**
+     * Get the List of responses being submitted
+     * 
+     * @param request
+     *            the HTTP request
+     * @param formResponse
+     *            the FormReponse being submitted
+     * @param listQuestions
+     *            the List of Question associated with the responses being submitted
+     * @return a List of FormQuestionResponse containing the new Responses' values
+     */
+    List<FormQuestionResponse> getSubmittedFormQuestionResponses( HttpServletRequest request, FormResponse formResponse, List<Question> listQuestions );
+
+    /**
+     * Check whether the values from the given FormQuestionResponse satisfy the Validators (regEx, file type, etc.) associated with them
+     * 
+     * @param formQuestionResponses
+     *            the List of FormQuestionResponse to check
+     * @return true if all the Responses are valid, returns false otherwise
+     */
+    boolean areFormQuestionResponsesValid( List<FormQuestionResponse> formQuestionResponses );
 }


### PR DESCRIPTION
Implemented the following behaviours:
1. Use the Validators defined for the Questions that the user is answering
2. Display an error on the fields containing values that failed the validation